### PR TITLE
Kvittering feilmelding

### DIFF
--- a/src/main/kotlin/dp/oppdrag/api/oppdrag.kt
+++ b/src/main/kotlin/dp/oppdrag/api/oppdrag.kt
@@ -6,11 +6,8 @@ import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
 import com.papsign.ktor.openapigen.route.route
 import dp.oppdrag.mapper.OppdragMapper
-import dp.oppdrag.model.OppdragId
-import dp.oppdrag.model.OppdragLagerStatus
+import dp.oppdrag.model.*
 import dp.oppdrag.model.OppdragSkjemaConstants.Companion.FAGSYSTEM
-import dp.oppdrag.model.Utbetalingsoppdrag
-import dp.oppdrag.model.Utbetalingsperiode
 import dp.oppdrag.repository.OppdragAlleredeSendtException
 import dp.oppdrag.repository.OppdragLagerRepository
 import dp.oppdrag.service.OppdragService
@@ -47,10 +44,10 @@ fun NormalOpenAPIRoute.oppdragApi(oppdragLagerRepository: OppdragLagerRepository
         }
 
         route("/status") {
-            authPost<Unit, String, OppdragId, TokenValidationContextPrincipal?>(
+            authPost<Unit, KvitteringDto, OppdragId, TokenValidationContextPrincipal?>(
                 info("Hent oppdragsstatus"),
                 exampleRequest = oppdragIdExample,
-                exampleResponse = OppdragLagerStatus.KVITTERT_OK.name
+                exampleResponse = KvitteringDto(OppdragLagerStatus.KVITTERT_OK)
             ) { _, request ->
                 Result.runCatching {
                     oppdragService.hentStatusForOppdrag(request)
@@ -59,7 +56,7 @@ fun NormalOpenAPIRoute.oppdragApi(oppdragLagerRepository: OppdragLagerRepository
                         respondNotFound("Fant ikke oppdrag med $request")
                     },
                     onSuccess = {
-                        respondOk(it.status.name)
+                        respondOk(KvitteringDto(it.status, it.kvitteringsmelding?.beskrMelding))
                     }
                 )
             }

--- a/src/main/kotlin/dp/oppdrag/model/KvitteringDto.kt
+++ b/src/main/kotlin/dp/oppdrag/model/KvitteringDto.kt
@@ -1,0 +1,3 @@
+package dp.oppdrag.model
+
+data class KvitteringDto(val status: OppdragLagerStatus, val feilmelding: String? = null)

--- a/src/main/kotlin/dp/oppdrag/utils/ApiUtils.kt
+++ b/src/main/kotlin/dp/oppdrag/utils/ApiUtils.kt
@@ -42,10 +42,10 @@ suspend inline fun <reified TResponse : Any> OpenAPIPipelineResponseContext<TRes
     )
 }
 
-suspend inline fun <reified TResponse : Any> OpenAPIPipelineResponseContext<TResponse>.respondOk(message: String) {
+suspend inline fun <TResponse : Any> OpenAPIPipelineResponseContext<TResponse>.respondOk(body: Any) {
     responder.respond(
         HttpStatusCode.OK,
-        message,
+        body,
         this.pipeline
     )
 }

--- a/src/main/kotlin/dp/oppdrag/utils/TestUtils.kt
+++ b/src/main/kotlin/dp/oppdrag/utils/TestUtils.kt
@@ -1,0 +1,32 @@
+package dp.oppdrag.utils
+
+import dp.oppdrag.defaultObjectMapper
+import dp.oppdrag.model.KvitteringDto
+import dp.oppdrag.model.OppdragLagerStatus
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headers
+import java.util.concurrent.TimeoutException
+
+inline fun <R> vent(
+    antallForsøk: Int = 100,
+    sovetidIMillisekunder: Long = 50,
+    ferdig: (R) -> Boolean = { it != null },
+    block: () -> R
+): R {
+
+    (1..antallForsøk).forEach {
+        val resultat = block()
+        if (ferdig(resultat)) {
+            return resultat
+        } else {
+            Thread.sleep(sovetidIMillisekunder)
+        }
+    }
+
+    throw TimeoutException("Fikk ikke resultat innen tidsfristen på ${antallForsøk * sovetidIMillisekunder} ms")
+}

--- a/src/test/kotlin/dp/oppdrag/AutokvitteringTestApp.kt
+++ b/src/test/kotlin/dp/oppdrag/AutokvitteringTestApp.kt
@@ -1,6 +1,7 @@
 package dp.oppdrag
 
 import com.ibm.mq.jms.MQQueue
+import dp.oppdrag.model.OppdragStatus
 import dp.oppdrag.utils.createQueueConnection
 import dp.oppdrag.utils.getProperty
 import io.ktor.server.netty.EngineMain
@@ -13,14 +14,13 @@ import javax.jms.MessageListener
 import javax.jms.Session
 import javax.jms.TextMessage
 
-object AutokvitteringTestApp : MessageListener {
+object AutokvitteringTestApp {
 
     @JvmStatic
     fun main(args: Array<String>) {
         konfigurer()
         startDB()
-        startMQ()
-        lyttEtterOppdragPåKø()
+        TestOppdragKø(OppdragStatus.OK)
         EngineMain.main(args)
     }
 
@@ -33,71 +33,11 @@ object AutokvitteringTestApp : MessageListener {
 
     private fun startDB() {
         val psql = KPostgreSQLContainer("postgres")
-            .withDatabaseName("dp-oppdrag")
-            .withUsername("dp-bruker")
-            .withPassword("dp-passord")
-
         psql.start()
 
         System.setProperty("DB_JDBC_URL", psql.jdbcUrl)
         System.setProperty("DB_USERNAME", psql.username)
         System.setProperty("DB_PASSWORD", psql.password)
-    }
-
-    fun startMQ(): KGenericContainer {
-        val queueManager = "QM1"
-        val appPassord = "passw0rd"
-        val mq = KGenericContainer("ibmcom/mq")
-            .withEnv("LICENSE", "accept")
-            .withEnv("MQ_QMGR_NAME", queueManager)
-            .withEnv("MQ_APP_PASSWORD", appPassord)
-            .withExposedPorts(1414, 9443)
-
-        mq.start()
-
-        System.setProperty("MQ_ENABLED", "true")
-        System.setProperty("MQ_QUEUEMANAGER", queueManager)
-        System.setProperty("MQ_PASSWORD", appPassord)
-        System.setProperty("MQ_PORT", mq.getMappedPort(1414).toString())
-        System.setProperty("MQ_HOSTNAME", "localhost")
-        System.setProperty("MQ_CHANNEL", "DEV.APP.SVRCONN")
-        System.setProperty("MQ_USER", "app")
-        System.setProperty("MQ_OPPDRAG_QUEUE", "DEV.QUEUE.1")
-        System.setProperty("MQ_KVITTERING_QUEUE", "DEV.QUEUE.2")
-        System.setProperty("MQ_AVSTEMMING_QUEUE", "DEV.QUEUE.3")
-
-        return mq
-    }
-
-    private fun lyttEtterOppdragPåKø() {
-        val queue = MQQueue(getProperty("MQ_OPPDRAG_QUEUE"))
-        val queueConnection = createQueueConnection()
-        val queueSession = queueConnection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE)
-        val queueReceiver = queueSession.createReceiver(queue)
-        queueReceiver.messageListener = this
-        queueConnection.start()
-    }
-
-    override fun onMessage(message: Message?) {
-        val meldingTilOppdrag = (message as TextMessage).text
-        val oppdrag = defaultXmlMapper.readValue(meldingTilOppdrag, Oppdrag::class.java)
-
-        val mmel = Mmel()
-        mmel.alvorlighetsgrad = "00" // OK
-        oppdrag.mmel = mmel
-
-        val queue = MQQueue(getProperty("MQ_KVITTERING_QUEUE"))
-        val queueConnection = createQueueConnection()
-        val queueSession = queueConnection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE)
-        val queueSender = queueSession.createSender(queue)
-
-        val kvitteringXml = defaultXmlMapper.writeValueAsString(oppdrag)
-        val kvittering = queueSession.createTextMessage(kvitteringXml)
-        queueSender.send(kvittering)
-
-        queueSender.close()
-        queueSession.close()
-        queueConnection.close()
     }
 }
 class KPostgreSQLContainer(imageName: String) : PostgreSQLContainer<KPostgreSQLContainer>(imageName)

--- a/src/test/kotlin/dp/oppdrag/TestOppdragKø.kt
+++ b/src/test/kotlin/dp/oppdrag/TestOppdragKø.kt
@@ -15,7 +15,6 @@ import javax.jms.TextMessage
 class TestOppdragKø(private val kvitteringStatus: OppdragStatus, private val kvitteringsmelding: String? = null): MessageListener, Closeable {
 
     private lateinit var mq: KGenericContainer
-
     init {
         startMQ()
         lyttEtterOppdragPåKø()

--- a/src/test/kotlin/dp/oppdrag/api/OppdragApiTest.kt
+++ b/src/test/kotlin/dp/oppdrag/api/OppdragApiTest.kt
@@ -218,19 +218,27 @@ class OppdragApiTest : TestBase() {
             assertEquals(HttpStatusCode.OK, response2.status)
             assertEquals("OK", response2.bodyAsText())
 
-            // Get status after sending Oppdrag
-            val response3 = client.post("/status") {
-                headers {
-                    append(HttpHeaders.ContentType, "application/json")
-                    append(HttpHeaders.Authorization, "Bearer ${token.serialize()}")
-                }
-                setBody(defaultObjectMapper.writeValueAsString(oppdragId))
-            }
+            var kvitteringDto: KvitteringDto?
+            var antallKjøringer = 0
 
-            assertEquals(HttpStatusCode.OK, response3.status)
-            val kvitteringDto = defaultObjectMapper.readValue(response3.bodyAsText(), KvitteringDto::class.java)
+            do {
+                antallKjøringer++
+                // Get status after sending Oppdrag
+                val response3 = client.post("/status") {
+                    headers {
+                        append(HttpHeaders.ContentType, "application/json")
+                        append(HttpHeaders.Authorization, "Bearer ${token.serialize()}")
+                    }
+                    setBody(defaultObjectMapper.writeValueAsString(oppdragId))
+                }
+
+                assertEquals(HttpStatusCode.OK, response3.status)
+                kvitteringDto = defaultObjectMapper.readValue(response3.bodyAsText(), KvitteringDto::class.java)
+            } while (kvitteringDto!!.status == OppdragLagerStatus.LAGT_PAA_KOE && antallKjøringer<100)
+
             assertNotNull(kvitteringDto.feilmelding)
             assertEquals(OppdragLagerStatus.KVITTERT_FUNKSJONELL_FEIL, kvitteringDto.status)
+
         }
     }
 

--- a/src/test/kotlin/dp/oppdrag/api/OppdragApiTest.kt
+++ b/src/test/kotlin/dp/oppdrag/api/OppdragApiTest.kt
@@ -1,6 +1,7 @@
 package dp.oppdrag.api
 
 import com.nimbusds.jwt.SignedJWT
+import dp.oppdrag.TestOppdragKø
 import dp.oppdrag.defaultObjectMapper
 import dp.oppdrag.model.*
 import dp.oppdrag.model.OppdragSkjemaConstants.Companion.FAGSYSTEM
@@ -8,11 +9,14 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+import java.lang.Thread.sleep
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class OppdragApiTest : TestBase() {
 
@@ -185,7 +189,49 @@ class OppdragApiTest : TestBase() {
         }
 
         assertEquals(HttpStatusCode.OK, response3.status)
-        assertEquals(OppdragLagerStatus.LAGT_PAA_KOE.name, response3.bodyAsText())
+        val kvitteringDto = defaultObjectMapper.readValue(response3.bodyAsText(), KvitteringDto::class.java)
+        assertNull(kvitteringDto.feilmelding)
+        assertEquals(OppdragLagerStatus.LAGT_PAA_KOE, kvitteringDto.status)
+    }
+
+    @Test
+    fun `skal få feilmelding når vi får feilkvittering fra oppdrag`() = setUpTestApplication {
+        val behandlingsId = 3L
+        val utbetalingsoppdrag = opprettUtbetalingsoppdrag(behandlingsId)
+        val oppdragId = OppdragId(
+            fagsystem = FAGSYSTEM,
+            personIdent = "01020312345",
+            behandlingsId = behandlingsId.toString()
+        )
+
+        val token: SignedJWT = mockOAuth2Server.issueToken(ISSUER_ID, "someclientid", DefaultOAuth2TokenCallback())
+
+        TestOppdragKø(OppdragStatus.AVVIST_FUNKSJONELLE_FEIL, "Personen finnes ikke i TPS").use {
+            val response2 = client.post("/oppdrag") {
+                headers {
+                    append(HttpHeaders.ContentType, "application/json")
+                    append(HttpHeaders.Authorization, "Bearer ${token.serialize()}")
+                }
+                setBody(defaultObjectMapper.writeValueAsString(utbetalingsoppdrag))
+            }
+
+            assertEquals(HttpStatusCode.OK, response2.status)
+            assertEquals("OK", response2.bodyAsText())
+
+            // Get status after sending Oppdrag
+            val response3 = client.post("/status") {
+                headers {
+                    append(HttpHeaders.ContentType, "application/json")
+                    append(HttpHeaders.Authorization, "Bearer ${token.serialize()}")
+                }
+                setBody(defaultObjectMapper.writeValueAsString(oppdragId))
+            }
+
+            assertEquals(HttpStatusCode.OK, response3.status)
+            val kvitteringDto = defaultObjectMapper.readValue(response3.bodyAsText(), KvitteringDto::class.java)
+            assertNotNull(kvitteringDto.feilmelding)
+            assertEquals(OppdragLagerStatus.KVITTERT_FUNKSJONELL_FEIL, kvitteringDto.status)
+        }
     }
 
     @Test

--- a/src/test/kotlin/dp/oppdrag/api/TestBase.kt
+++ b/src/test/kotlin/dp/oppdrag/api/TestBase.kt
@@ -1,6 +1,8 @@
 package dp.oppdrag.api
 
 import com.zaxxer.hikari.HikariDataSource
+import dp.oppdrag.AutokvitteringTestApp
+import dp.oppdrag.KGenericContainer
 import dp.oppdrag.defaultDataSource
 import dp.oppdrag.module
 import io.ktor.server.config.*
@@ -22,7 +24,7 @@ open class TestBase {
         var mockOAuth2Server = MockOAuth2Server()
 
         @Container
-        private val container: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:14-alpine")
+        private val dbContainer: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:14-alpine")
 
         @BeforeAll
         @JvmStatic
@@ -31,9 +33,9 @@ open class TestBase {
             mockOAuth2Server.start(8091)
 
             defaultDataSource = HikariDataSource().apply {
-                jdbcUrl = container.jdbcUrl
-                username = container.username
-                password = container.password
+                jdbcUrl = dbContainer.jdbcUrl
+                username = dbContainer.username
+                password = dbContainer.password
 
                 validate()
             }


### PR DESCRIPTION
Lager støtte for å dra opp en oppdragemulator i forbindelse med tester. I praksis er det to MQ-køer, en for oppdrag til OS og en med kvitteringer. Det kan styres hva slags kvitteringer som returneres. 

Utvider status-endepunktet til å returnere eventuell feilmelding fra OS