### PR TITLE
Komprimer alle UUID-er vi sender til OS siden OS ikke takler id-felter over 30 tegn

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/oppdrag/domene/OppdragIdMapping.kt
+++ b/src/main/kotlin/no/nav/dagpenger/oppdrag/domene/OppdragIdMapping.kt
@@ -2,12 +2,12 @@ package no.nav.dagpenger.oppdrag.domene
 
 import no.nav.dagpenger.kontrakter.felles.tilFagsystem
 import no.nav.dagpenger.kontrakter.oppdrag.OppdragId
+import no.nav.dagpenger.oppdrag.iverksetting.UuidUtils.dekomprimer
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
-import java.util.*
 
 val Oppdrag.id: OppdragId
     get() = OppdragId(
         this.oppdrag110.kodeFagomraade.tilFagsystem(),
         this.oppdrag110.oppdragGjelderId,
-        UUID.fromString(this.oppdrag110.oppdragsLinje150?.get(0)?.henvisning!!)
+        this.oppdrag110.oppdragsLinje150?.get(0)?.henvisning!!.dekomprimer()
     )

--- a/src/main/kotlin/no/nav/dagpenger/oppdrag/iverksetting/OppdragMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/oppdrag/iverksetting/OppdragMapper.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.oppdrag.iverksetting
 
 import no.nav.dagpenger.kontrakter.oppdrag.Utbetalingsoppdrag
 import no.nav.dagpenger.kontrakter.oppdrag.Utbetalingsperiode
+import no.nav.dagpenger.oppdrag.iverksetting.UuidUtils.komprimer
 import no.trygdeetaten.skjema.oppdrag.ObjectFactory
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import no.trygdeetaten.skjema.oppdrag.Oppdrag110
@@ -34,7 +35,7 @@ class OppdragMapper {
             kodeAksjon = OppdragSkjemaConstants.KODE_AKSJON
             kodeEndring = EndringsKode.fromKode(utbetalingsoppdrag.kodeEndring.name).kode
             kodeFagomraade = utbetalingsoppdrag.fagSystem.kode
-            fagsystemId = utbetalingsoppdrag.saksnummer.toString()
+            fagsystemId = utbetalingsoppdrag.saksnummer.komprimer()
             utbetFrekvens = UtbetalingsfrekvensKode.MÅNEDLIG.kode
             oppdragGjelderId = utbetalingsoppdrag.aktoer
             datoOppdragGjelderFom = OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.toXMLDate()
@@ -53,6 +54,7 @@ class OppdragMapper {
         utbetalingsperiode: Utbetalingsperiode,
         utbetalingsoppdrag: Utbetalingsoppdrag
     ): OppdragsLinje150 {
+        val sakIdKomprimert = utbetalingsoppdrag.saksnummer.komprimer()
 
         val attestant = objectFactory.createAttestant180().apply {
             attestantId = utbetalingsoppdrag.saksbehandlerId
@@ -67,12 +69,12 @@ class OppdragMapper {
             }
             if (!utbetalingsperiode.erEndringPåEksisterendePeriode) {
                 utbetalingsperiode.forrigePeriodeId?.let {
-                    refDelytelseId = utbetalingsoppdrag.saksnummer.toString() + it
-                    refFagsystemId = utbetalingsoppdrag.saksnummer.toString()
+                    refDelytelseId = "$sakIdKomprimert#$it"
+                    refFagsystemId = sakIdKomprimert
                 }
             }
             vedtakId = utbetalingsperiode.datoForVedtak.toString()
-            delytelseId = utbetalingsoppdrag.saksnummer.toString() + utbetalingsperiode.periodeId
+            delytelseId = "$sakIdKomprimert#${utbetalingsperiode.periodeId}"
             kodeKlassifik = utbetalingsperiode.klassifisering
             datoVedtakFom = utbetalingsperiode.vedtakdatoFom.toXMLDate()
             datoVedtakTom = utbetalingsperiode.vedtakdatoTom.toXMLDate()
@@ -82,7 +84,7 @@ class OppdragMapper {
             brukKjoreplan = OppdragSkjemaConstants.BRUK_KJØREPLAN_DEFAULT
             saksbehId = utbetalingsoppdrag.saksbehandlerId
             utbetalesTilId = utbetalingsperiode.utbetalesTil
-            henvisning = utbetalingsperiode.behandlingId.toString()
+            henvisning = utbetalingsperiode.behandlingId.komprimer()
             attestant180.add(attestant)
 
             utbetalingsperiode.utbetalingsgrad?.let { utbetalingsgrad ->

--- a/src/main/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtils.kt
+++ b/src/main/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtils.kt
@@ -1,0 +1,21 @@
+package no.nav.dagpenger.oppdrag.iverksetting
+
+import java.nio.ByteBuffer
+import java.util.Base64
+import java.util.UUID
+
+object UuidUtils {
+
+    fun UUID.komprimer(): String {
+        val bb: ByteBuffer = ByteBuffer.allocate(java.lang.Long.BYTES * 2)
+        bb.putLong(this.mostSignificantBits)
+        bb.putLong(this.leastSignificantBits)
+        val array: ByteArray = bb.array()
+        return Base64.getEncoder().encodeToString(array)
+    }
+
+    fun String.dekomprimer(): UUID {
+        val byteBuffer: ByteBuffer = ByteBuffer.wrap(Base64.getDecoder().decode(this))
+        return UUID(byteBuffer.long, byteBuffer.long)
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/KontraktTilOppdragTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/KontraktTilOppdragTest.kt
@@ -4,6 +4,7 @@ import no.nav.dagpenger.kontrakter.felles.Fagsystem
 import no.nav.dagpenger.kontrakter.oppdrag.Opphør
 import no.nav.dagpenger.kontrakter.oppdrag.Utbetalingsoppdrag
 import no.nav.dagpenger.kontrakter.oppdrag.Utbetalingsperiode
+import no.nav.dagpenger.oppdrag.iverksetting.UuidUtils.komprimer
 import no.trygdeetaten.skjema.oppdrag.Oppdrag110
 import no.trygdeetaten.skjema.oppdrag.OppdragsLinje150
 import org.junit.jupiter.api.Assertions
@@ -101,7 +102,7 @@ class KontraktTilOppdragTest {
         Assertions.assertEquals(OppdragSkjemaConstants.KODE_AKSJON, oppdrag110.kodeAksjon)
         Assertions.assertEquals(utbetalingsoppdrag.kodeEndring.name, oppdrag110.kodeEndring.toString())
         Assertions.assertEquals(utbetalingsoppdrag.fagSystem.kode, oppdrag110.kodeFagomraade)
-        Assertions.assertEquals(utbetalingsoppdrag.saksnummer.toString(), oppdrag110.fagsystemId)
+        Assertions.assertEquals(utbetalingsoppdrag.saksnummer.komprimer(), oppdrag110.fagsystemId)
         Assertions.assertEquals(UtbetalingsfrekvensKode.MÅNEDLIG.kode, oppdrag110.utbetFrekvens)
         Assertions.assertEquals(utbetalingsoppdrag.aktoer, oppdrag110.oppdragGjelderId)
         Assertions.assertEquals(OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.toXMLDate(), oppdrag110.datoOppdragGjelderFom)
@@ -133,7 +134,7 @@ class KontraktTilOppdragTest {
         assertOpphør(utbetalingsperiode, oppdragsLinje150)
         Assertions.assertEquals(utbetalingsperiode.datoForVedtak.toString(), oppdragsLinje150.vedtakId)
         Assertions.assertEquals(
-            utbetalingsoppdrag.saksnummer.toString() + utbetalingsperiode.periodeId.toString(),
+            utbetalingsoppdrag.saksnummer.komprimer() + "#" + utbetalingsperiode.periodeId.toString(),
             oppdragsLinje150.delytelseId
         )
         Assertions.assertEquals(utbetalingsperiode.klassifisering, oppdragsLinje150.kodeKlassifik)
@@ -145,13 +146,13 @@ class KontraktTilOppdragTest {
         Assertions.assertEquals(OppdragSkjemaConstants.BRUK_KJØREPLAN_DEFAULT, oppdragsLinje150.brukKjoreplan)
         Assertions.assertEquals(utbetalingsoppdrag.saksbehandlerId, oppdragsLinje150.saksbehId)
         Assertions.assertEquals(utbetalingsoppdrag.aktoer, oppdragsLinje150.utbetalesTilId)
-        Assertions.assertEquals(utbetalingsperiode.behandlingId.toString(), oppdragsLinje150.henvisning)
+        Assertions.assertEquals(utbetalingsperiode.behandlingId.komprimer(), oppdragsLinje150.henvisning)
         Assertions.assertEquals(utbetalingsoppdrag.saksbehandlerId, oppdragsLinje150.attestant180[0].attestantId)
         Assertions.assertEquals(utbetalingsperiode.utbetalingsgrad, oppdragsLinje150.grad170.firstOrNull()?.grad?.toInt())
 
         if (utbetalingsperiode.forrigePeriodeId !== null && !utbetalingsperiode.erEndringPåEksisterendePeriode)
             Assertions.assertEquals(
-                utbetalingsoppdrag.saksnummer.toString() + utbetalingsperiode.forrigePeriodeId.toString(),
+                utbetalingsoppdrag.saksnummer.komprimer() + "#" + utbetalingsperiode.forrigePeriodeId.toString(),
                 oppdragsLinje150.refDelytelseId
             )
     }

--- a/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtilsTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtilsTest.kt
@@ -23,8 +23,5 @@ class UuidUtilsTest {
         val komprimert = originalUUID.komprimer()
 
         assertEquals(24, komprimert.length)
-
-        val uuid2 = UUID.fromString("62640ece-f941-11ed-be56-0242ac120002")
-        println(uuid2.komprimer())
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtilsTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/oppdrag/iverksetting/UuidUtilsTest.kt
@@ -1,0 +1,30 @@
+package no.nav.dagpenger.oppdrag.iverksetting
+
+import no.nav.dagpenger.oppdrag.iverksetting.UuidUtils.dekomprimer
+import no.nav.dagpenger.oppdrag.iverksetting.UuidUtils.komprimer
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class UuidUtilsTest {
+
+    @Test
+    fun `UUID skal være identisk etter komprimering og dekomprimering`() {
+        val originalUUID = UUID.randomUUID()
+        val komprimert = originalUUID.komprimer()
+        val dekomprimert = komprimert.dekomprimer()
+
+        assertEquals(originalUUID, dekomprimert)
+    }
+
+    @Test
+    fun `komprimert UUID skal være 24 tegn`() {
+        val originalUUID = UUID.randomUUID()
+        val komprimert = originalUUID.komprimer()
+
+        assertEquals(24, komprimert.length)
+
+        val uuid2 = UUID.fromString("62640ece-f941-11ed-be56-0242ac120002")
+        println(uuid2.komprimer())
+    }
+}

--- a/src/test/resources/kvittering-akseptert.xml
+++ b/src/test/resources/kvittering-akseptert.xml
@@ -8,7 +8,7 @@
         <kodeAksjon>1</kodeAksjon>
         <kodeEndring>NY</kodeEndring>
         <kodeFagomraade>DP</kodeFagomraade>
-        <fagsystemId>62640ece-f941-11ed-be56-0242ac120002</fagsystemId>
+        <fagsystemId>YmQOzvlBEe2+VgJCrBIAAg==</fagsystemId>
         <utbetFrekvens>MND</utbetFrekvens>
         <oppdragGjelderId>12345678911</oppdragGjelderId>
         <datoOppdragGjelderFom>2000-01-01+01:00</datoOppdragGjelderFom>
@@ -26,7 +26,7 @@
         <oppdrags-linje-150>
             <kodeEndringLinje>NY</kodeEndringLinje>
             <vedtakId>2019-12-16</vedtakId>
-            <delytelseId>62640ece-f941-11ed-be56-0242ac1200021</delytelseId>
+            <delytelseId>YmQOzvlBEe2+VgJCrBIAAg==#1</delytelseId>
             <kodeKlassifik>DPORAS</kodeKlassifik>
             <datoVedtakFom>2019-12-20+01:00</datoVedtakFom>
             <datoVedtakTom>2020-12-21+01:00</datoVedtakTom>
@@ -36,7 +36,7 @@
             <brukKjoreplan>N</brukKjoreplan>
             <saksbehId>Z992991</saksbehId>
             <utbetalesTilId>12345678911</utbetalesTilId>
-            <henvisning>62640ece-f941-11ed-be56-0242ac120002</henvisning>
+            <henvisning>YmQOzvlBEe2+VgJCrBIAAg==</henvisning>
             <attestant-180>
                 <attestantId>Z992991</attestantId>
             </attestant-180>

--- a/src/test/resources/kvittering-avvist.xml
+++ b/src/test/resources/kvittering-avvist.xml
@@ -12,7 +12,7 @@
         <kodeAksjon>1</kodeAksjon>
         <kodeEndring>NY</kodeEndring>
         <kodeFagomraade>DP</kodeFagomraade>
-        <fagsystemId>62640ece-f941-11ed-be56-0242ac120002</fagsystemId>
+        <fagsystemId>YmQOzvlBEe2+VgJCrBIAAg==</fagsystemId>
         <utbetFrekvens>MND</utbetFrekvens>
         <oppdragGjelderId>12345678911</oppdragGjelderId>
         <datoOppdragGjelderFom>2000-01-01+01:00</datoOppdragGjelderFom>
@@ -30,7 +30,7 @@
         <oppdrags-linje-150>
             <kodeEndringLinje>NY</kodeEndringLinje>
             <vedtakId>2019-12-12</vedtakId>
-            <delytelseId>62640ece-f941-11ed-be56-0242ac1200021</delytelseId>
+            <delytelseId>YmQOzvlBEe2+VgJCrBIAAg==#1</delytelseId>
             <kodeKlassifik>DPORAS</kodeKlassifik>
             <datoVedtakFom>2019-12-20+01:00</datoVedtakFom>
             <datoVedtakTom>2020-12-21+01:00</datoVedtakTom>
@@ -40,7 +40,7 @@
             <brukKjoreplan>N</brukKjoreplan>
             <saksbehId>Z992991</saksbehId>
             <utbetalesTilId>12345678911</utbetalesTilId>
-            <henvisning>62640ece-f941-11ed-be56-0242ac120002</henvisning>
+            <henvisning>YmQOzvlBEe2+VgJCrBIAAg==</henvisning>
             <attestant-180>
                 <attestantId>Z992991</attestantId>
             </attestant-180>


### PR DESCRIPTION
Jeg oppdaget en feil mot OS når vi sender utbetalinger med flere perioder. Da fikk vi kvitteringer som ser typ slik ut: "DELYTELSE-ID finnes i oppdragsbasen fra før: 9bb77e53-1551-428a-9" 
Det virker altså som at våre UUID-er på 36 tegn blir kuttet i OS. Jeg sjekket skjemaet og der står det at maks antall tegn er 30 for både fagsystemId, delytelseId og henvisning. 

Jeg tenker at det er lettere for oss å komprimere UUID-en til under 30 tegn enn å holde styr på en separat id for saksnummer og behandlingsid. For å få komprimert UUID-en, utnytter jeg UUID sin most- og least significant bits sammen med base64 for å forkorte UUID-en fra 36 tegn til 24 tegn. Her kan vi konvertere tilbake/dekomprimere og få identisk UUID, dvs. vi mister ikke noe info i komprimeringen.

Med ID på 24 tegn har vi 6 ledige tegn til løpenummer i delytelseId. Jeg liker å se løpenumrene i klartekst og har derfor valgt å separere den base64-enkodede UUIDen og løpenummeret med et #-tegn slik at det er lett å se når løpenummeret starter. Regner med at vi ikke vil få løpenumre > 99 999, dvs 5 tegn til løpenummer bør holde. I XML-en vil delytelseId se slik ut: 

`<delytelseId>Qc7iXP7WREGfmyCQxfDj4Q==#1</delytelseId>`
`<delytelseId>Qc7iXP7WREGfmyCQxfDj4Q==#2</delytelseId>`
Osv... 

Merk at jeg komprimerer UUID-en så "seint" som mulig fordi jeg helst ikke vil at dp-oppdrag skal måtte forholde seg så mye til den. Derfor komprimerer jeg UUID-en i det vi genererer Oppdrag110-xml-en, og dekomprimerer den så fort vi får kvitteringen. I databasen lagres UUID-en fortsatt i klartekst.  

Denne løsningen er manuelltestet i preprod med flere perioder. Vi får kvittert ok, så dette bør fikse den originale bugen. 